### PR TITLE
Update 91-recovery-partition-grub-entry

### DIFF
--- a/postinstall.d/91-recovery-partition-grub-entry
+++ b/postinstall.d/91-recovery-partition-grub-entry
@@ -10,7 +10,7 @@ echo "
 #!/bin/sh
 exec tail -n +3 \$0
 ### BEGIN Recuperacion ###
-   menuentry "Sistema de recuperación" --class gnu-linux --class gnu --class os {
+   menuentry \"Sistema de recuperación\" --class gnu-linux --class gnu --class os {
      insmod part_msdos
      insmod ext2
      set root='(hd0,msdos5)'
@@ -18,7 +18,7 @@ exec tail -n +3 \$0
      linux /vmlinuz root=/dev/sda5
      initrd /initrd.img
    }
-### END Recuperacion ###" >> /etc/grub.d/40_conig-recovery
+### END Recuperacion ###" > /etc/grub.d/40_conig-recovery
 
 echo "Agregada la partición de recuperación al grub"
 chmod +x /etc/grub.d/40_conig-recovery


### PR DESCRIPTION
Segun cohiote en http://huayra.conectarigualdad.gob.ar/foro/index.php/topic,473.msg1802.html#msg1802
No se presenta correctamente el titulo en el menú y si reinstala el paquete, se duplica la entrada de Recuperación en el menú.
Se "escaparon" las comillas del titulo y se cambio el operador de redireccion.
